### PR TITLE
Relative T1-weighted signal difference pipelines

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -31,7 +31,7 @@ SESSIONS=[f"ses-{i+1:02d}" for i in range(config["num_sessions"])]
 rule all:
   input:
     expand(
-      "data/mri_processed_data/{subject}/statistics/{subject}_statstable.csv"
+      "data/mri_processed_data/{subject}/statistics/{subject}_statstable.csv",
       subject=config["subjects"],
     )
 
@@ -40,12 +40,14 @@ module preprocessing:
   prefix: "data/mri_dataset"
   config: config
 
-use rule * from preprocessing as preprocessing_*
+#use rule * from preprocessing as preprocessing_*
 
 include: "workflows_additional/register"
 include: "workflows_additional/recon-all"
 include: "workflows_additional/T1maps"
+include: "workflows_additional/T1w_signal_intensities"
 include: "workflows_additional/concentration-estimate"
 include: "workflows_additional/statistics"
 include: "workflows_additional/mesh-generation"
 include: "workflows_additional/mri2fem"
+include: "workflows_additional/dti"

--- a/gmri2fem/analysis/region_quantities.py
+++ b/gmri2fem/analysis/region_quantities.py
@@ -48,11 +48,16 @@ def create_dataframe(
 
     data = nifti1.load(mri_path).get_fdata(dtype=np.single)
     timetable = pd.read_csv(timestamps_path)
-    timestamp = timetable.loc[
-        (timetable["sequence_label"] == timestamp_sequence)
-        & (timetable["subject"] == subject)
-        & (timetable["session"] == session)
-    ]["acquisition_relative_injection"].item()
+    try:
+        timestamp = timetable.loc[
+            (timetable["sequence_label"] == timestamp_sequence)
+            & (timetable["subject"] == subject)
+            & (timetable["session"] == session)
+        ]["acquisition_relative_injection"]
+        timestamp = timestamp.item()
+    except ValueError as e:
+        print(timetable)
+        raise e
 
     regions_stat_functions = {
         "mean": np.mean,

--- a/gmri2fem/mriprocessing/normalize_images.py
+++ b/gmri2fem/mriprocessing/normalize_images.py
@@ -5,8 +5,8 @@ import numpy as np
 
 
 def normalize_image(image_path: Path, refroi_path: Path, outputpath: Path) -> Path:
-    image = nibabel.freesurfer.mghformat.load(image_path)
-    refroi = nibabel.freesurfer.mghformat.load(refroi_path)
+    image = nibabel.nifti1.load(image_path)
+    refroi = nibabel.nifti1.load(refroi_path)
 
     assert np.allclose(
         refroi.affine, image.affine
@@ -15,10 +15,8 @@ def normalize_image(image_path: Path, refroi_path: Path, outputpath: Path) -> Pa
     ref_mask = refroi.get_fdata().astype(bool)
 
     normalized_image_data = image_data / np.median(image_data[ref_mask])
-    normalized_image = nibabel.freesurfer.mghformat.MGHImage(
-        normalized_image_data, image.affine
-    )
-    nibabel.freesurfer.mghformat.save(normalized_image, outputpath)
+    normalized_image = nibabel.nifti1.Nifti1Image(normalized_image_data, image.affine)
+    nibabel.nifti1.save(normalized_image, outputpath)
     return outputpath
 
 

--- a/gmri2fem/mriprocessing/orbital_refroi.py
+++ b/gmri2fem/mriprocessing/orbital_refroi.py
@@ -1,0 +1,74 @@
+import nibabel
+import matplotlib.pyplot as plt
+import numpy as np
+import skimage
+import scipy
+from scipy.stats import multivariate_normal
+
+from pathlib import Path
+import itertools
+
+from gmri2fem.mriprocessing.mask_csf import largest_island
+
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--T1w_dir", type=Path, required=True)
+parser.add_argument("--segmentation", type=Path, required=True)
+parser.add_argument("--output", type=Path, required=True)
+args = parser.parse_args()
+
+
+image_paths = sorted(args.T1w_dir.glob("*T1w*"))
+vols = [nibabel.nifti1.load(path).get_fdata(dtype=np.single) for path in image_paths]
+vols = np.array(vols)
+seg_nii = nibabel.nifti1.load(args.segmentation)
+seg_data = seg_nii.get_fdata().astype(np.uint16)
+
+assert seg_data.shape == vols[0].shape
+
+
+# LUT-values of regions to look for to find slice in R,A,S-directions respectively
+axes_seg_indices = [1012, 1027, 1033]
+centers = [
+    [np.rint(x.mean()).astype(int) for x in np.where(seg_data == label)][idx]
+    for idx, label in enumerate(axes_seg_indices)
+]
+cov_scale = [3, 1.5, 6]
+cov = [
+    cov_scale[idx] * [x.var() for x in np.where(seg_data == label)][idx]
+    for idx, label in enumerate(axes_seg_indices)
+]
+G = multivariate_normal(mean=centers, cov=cov)
+
+pos = np.fromiter(
+    itertools.product(
+        *(
+            np.arange(ci - 3 * np.sqrt(di), ci + 3 * np.sqrt(di))
+            for ci, di in zip(centers, cov)
+        )
+    ),
+    dtype=np.dtype((int, 3)),
+)
+I, J, K = pos.T
+
+binary = np.ones(vols[0].shape, dtype=bool)
+image = np.zeros_like(vols[0])
+for idx, vol in enumerate(vols):
+    image[I, J, K] = vol[I, J, K] * G.pdf(pos)
+    thresh = skimage.filters.threshold_otsu(image)
+    binary *= image > thresh
+
+binary = skimage.morphology.erosion(binary, footprint=skimage.morphology.ball(5))
+binary = largest_island(binary)
+temporal_std = (vols[:, binary] / np.median(vols[:, binary], axis=1, keepdims=1)).std(
+    axis=0
+)
+binary[binary] = (np.abs(vols[0, binary] / np.median(vols[0, binary]) - 1) < 0.25) * (
+    temporal_std < 0.1
+)
+refroi_nii = nibabel.nifti1.Nifti1Image(
+    binary.astype(np.single), affine=seg_nii.affine, header=seg_nii.header
+)
+nibabel.nifti1.save(refroi_nii, args.output)

--- a/gmri2fem/mriprocessing/t1w_signal_increase.py
+++ b/gmri2fem/mriprocessing/t1w_signal_increase.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import nibabel
+import numpy as np
+
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--reference", type=Path, required=True)
+parser.add_argument("--image", type=Path, required=True)
+parser.add_argument("--mask", type=Path, required=True)
+parser.add_argument("--output", type=Path, required=True)
+args = parser.parse_args()
+
+ref_nii = nibabel.nifti1.load(args.reference)
+ref = ref_nii.get_fdata(dtype=np.single)
+vol_nii = nibabel.nifti1.load(args.image)
+vol = vol_nii.get_fdata(dtype=np.single)
+
+brainmask_nii = nibabel.nifti1.load(args.mask)
+brainmask = brainmask_nii.get_fdata().astype(bool) * (ref > 0)
+signal_diff = np.nan * np.zeros_like(vol)
+signal_diff[brainmask] = vol[brainmask] / ref[brainmask] - 1
+signal_diff_nii = nibabel.nifti1.Nifti1Image(
+    signal_diff, affine=vol_nii.affine, header=vol_nii.header
+)
+nibabel.nifti1.save(signal_diff_nii, args.output)

--- a/workflows_additional/T1w_signal_intensities
+++ b/workflows_additional/T1w_signal_intensities
@@ -1,0 +1,14 @@
+rule T1w_signal_intensity_increase:
+  input:
+    reference="data/mri_processed_data/{subject}/T1w_normalized/{subject}_ses-01_T1w_normalized.nii.gz",
+    image="data/mri_processed_data/{subject}/T1w_normalized/{subject}_{session}_T1w_normalized.nii.gz",
+    mask="data/mri_processed_data/{subject}/{subject}_mask-intracranial.nii.gz",
+  output:
+    "data/mri_processed_data/{subject}/T1w_signal_difference/{subject}_{session}_T1w_signal-difference.nii.gz",
+  shell:
+    "python gmri2fem/mriprocessing/t1w_signal_increase.py"
+      " --reference {input.reference}"
+      " --image {input.image}"
+      " --mask {input.mask}"
+      " --output {output}"
+

--- a/workflows_additional/concentration-estimate
+++ b/workflows_additional/concentration-estimate
@@ -1,39 +1,53 @@
 rule concentration_estimate:
-    input:
-        image="data/mri_processed_data/{subject}/T1maps/{subject}_{session}_T1map.nii.gz",
-        reference="data/mri_processed_data/{subject}/T1maps/{subject}_ses-01_T1map.nii.gz",
-    output:
-        "data/mri_processed_data/{subject}/concentrations/{subject}_{session}_concentration.nii.gz"
-    shell:
-        "python gmri2fem/mriprocessing/estimate_concentration.py"
-        " --input {input.image}"
-        " --reference {input.reference}"
-        " --output {output}"
-        " --r1 0.0045"
+  input:
+    image="data/mri_processed_data/{subject}/T1maps/{subject}_{session}_T1map.nii.gz",
+    reference="data/mri_processed_data/{subject}/T1maps/{subject}_ses-01_T1map.nii.gz",
+  output:
+    "data/mri_processed_data/{subject}/concentrations/{subject}_{session}_concentration.nii.gz"
+  shell:
+    "python gmri2fem/mriprocessing/estimate_concentration.py"
+      " --input {input.image}"
+      " --reference {input.reference}"
+      " --output {output}"
+      " --r1 0.0045"
 
+# rule grow_refroi:
+#   input:
+#     seed="data/mri_processed_data/{subject}/{subject}_refroi_seed.mgz",
+#     references=expand(
+#       "data/mri_processed_data/{{subject}}/registered/{{subject}}_{session}_T1w_registered.mgz",
+#       session=SESSIONS
+#     )
+#   output:
+#     "data/mri_processed_data/{subject}/{subject}_refroi.mgz",
+#   shell:
+#     "python gmri2fem/mriprocessing/grow_refroi.py"
+#       " --seed {input.seed}"
+#       " --references {input.references}"
+#       " --output {output}"
 
-rule grow_refroi:
-    input:
-        seed="data/mri_processed_data/{subject}/{subject}_refroi_seed.mgz",
-        references=expand(
-            "data/mri_processed_data/{{subject}}/registered/{{subject}}_{session}_T1w_registered.mgz",
-            session=SESSIONS
-        )
-    output:
-        "data/mri_processed_data/{subject}/{subject}_refroi.mgz",
-    shell:
-        "python gmri2fem/mriprocessing/grow_refroi.py"
-        " --seed {input.seed}"
-        " --references {input.references}"
-        " --output {output}"
+rule create_refroi:
+  input: 
+    T1w = lambda wc: [
+      f"data/mri_processed_data/{{subject}}/registered/{{subject}}_{session}_T1w_registered.nii.gz"
+      for session in SESSIONS#[wc.subject]
+    ],
+    segmentation= "data/mri_processed_data/{subject}/{subject}_aparc+aseg_refined.nii.gz",
+  output:
+    "data/mri_processed_data/{subject}/{subject}_refroi-left-orbital.nii.gz",
+  shell:
+    "python gmri2fem/mriprocessing/orbital_refroi.py"
+      " --T1w_dir $(dirname '{input.T1w[0]}')"
+      " --segmentation {input.segmentation}"
+      " --output {output}"
 
 
 rule normalize_T1w:
     input:
-        image="data/mri_processed_data/{subject}/registered/{subject}_{session}_T1w_registered.mgz",
-        refroi="data/mri_processed_data/{subject}/{subject}_refroi.mgz",
+        image="data/mri_processed_data/{subject}/registered/{subject}_{session}_T1w_registered.nii.gz",
+        refroi="data/mri_processed_data/{subject}/{subject}_refroi-left-orbital.nii.gz",
     output:
-        "data/mri_processed_data/{subject}/T1w_normalized/{subject}_{session}_T1w_normalized.mgz"
+        "data/mri_processed_data/{subject}/T1w_normalized/{subject}_{session}_T1w_normalized.nii.gz"
     shell:
         "python gmri2fem/mriprocessing/normalize_images.py"
         " --image {input.image}"

--- a/workflows_additional/statistics
+++ b/workflows_additional/statistics
@@ -1,11 +1,12 @@
 rule segment_refinements:
   input:
-    reference="data/mri_processed_data/{subject}/T1maps/{subject}_ses-01_T1map.nii.gz",
+    reference="data/mri_processed_data/{subject}/registered/{subject}_ses-01_T1w_registered.nii.gz",
     segmentation="data/mri_processed_data/freesurfer/{subject}/mri/aparc+aseg.mgz",
     csfmask="data/mri_processed_data/{subject}/{subject}_csfmask.nii.gz",
   output:
     refined="data/mri_processed_data/{subject}/{subject}_aparc+aseg_refined.nii.gz",
-    csf_segmentation="data/mri_processed_data/{subject}/{subject}_aparc+aseg_csfseg.nii.gz"
+    csf_segmentation="data/mri_processed_data/{subject}/{subject}_aparc+aseg_csfseg.nii.gz",
+    intracranial_mask="data/mri_processed_data/{subject}/{subject}_mask-intracranial.nii.gz"
   shell:
     "python gmri2fem/analysis/segmentation_refinement.py"
     " --fs_seg {input.segmentation}"
@@ -13,7 +14,63 @@ rule segment_refinements:
     " --csfmask {input.csfmask}"
     " --output_seg {output.refined}"
     " --output_csfseg {output.csf_segmentation}"
+    " --intracranial_mask {output.intracranial_mask}"
 
+
+rule T1w_sig_diff_stats:
+    input:
+      data="data/mri_processed_data/{subject}/T1w_signal_difference/{subject}_{session}_T1w_signal-difference.nii.gz",
+      segmentation="data/mri_processed_data/{subject}/{subject}_aparc+aseg_refined.nii.gz",
+      timestamps="data/mri_dataset/timetable.csv",
+      lutfile="data/mri_processed_data/freesurfer_lut.json"
+    output:
+      "data/mri_processed_data/{subject}/statistics/{subject}_{session}_T1w-sigdiff_statstable.csv"
+    shell:
+      "python gmri2fem/analysis/region_quantities.py"
+      " --subjectid {wildcards.subject}"
+      " --subject_session {wildcards.session}"
+      " --sequence T1w-sig-diff"
+      " --timestamp_sequence T1w"
+      " --data {input.data}"
+      " --seg {input.segmentation}"
+      " --timestamps {input.timestamps}"
+      " --lutfile {input.lutfile}"
+      " --output {output}"
+
+
+rule T1w_sig_diff_csf_stats:
+    input:
+      data="data/mri_processed_data/{subject}/T1w_signal_difference/{subject}_{session}_T1w_signal-difference.nii.gz",
+      segmentation="data/mri_processed_data/{subject}/{subject}_aparc+aseg_csfseg.nii.gz",
+      timestamps="data/mri_dataset/timetable.csv",
+      lutfile="data/mri_processed_data/freesurfer_lut.json"
+    output:
+      "data/mri_processed_data/{subject}/statistics/{subject}_{session}_T1w-sigdiff-csf_statstable.csv"
+    shell:
+      "python gmri2fem/analysis/region_quantities.py"
+      " --subjectid {wildcards.subject}"
+      " --subject_session {wildcards.session}"
+      " --sequence T1w-sig-diff-csf"
+      " --timestamp_sequence T1w"
+      " --data {input.data}"
+      " --seg {input.segmentation}"
+      " --timestamps {input.timestamps}"
+      " --lutfile {input.lutfile}"
+      " --output {output}"
+
+
+rule T1w_sigdiff_collected:
+  input:
+    expand(
+      "data/mri_processed_data/{{subject}}/statistics/{{subject}}_{session}_T1w-sigdiff_statstable.csv",
+      session=SESSIONS
+    )
+  output:
+    "data/mri_processed_data/{subject}/statistics/{subject}_T1w-sigdiff_statstable.csv",
+  shell:
+    "python gmri2fem/analysis/concat_tables.py"
+    " --input {input}"
+    " --output {output}"
 
 rule LookLocker_stats:
     input:
@@ -136,7 +193,7 @@ rule collected:
     expand(
       "data/mri_processed_data/{{subject}}/statistics/{{subject}}_{session}_{sequence}_statstable.csv",
       session=SESSIONS,
-      sequence=["LookLocker", "T1w", "mixed", "concentration", "concentration_csf"]
+      sequence=["LookLocker", "T1w", "mixed", "concentration", "concentration_csf", "T1w-sigdiff", "T1w-sigdiff-csf"]
     )
   output:
     "data/mri_processed_data/{subject}/statistics/{subject}_statstable.csv",


### PR DESCRIPTION
- added automatic refroi-generation for T1w normalization (orbital_refroi.py)
- added error check 
- adapted Snakefiles to use with automatic refroi generation. 
- abstracted reference image used in segmentation_refinement from T1map, such that we can use the T1w-image for segmentation.
- changed mghformat in some scripts to nifti1.
- created script for computing relative signal differences from one image to the next.
- added workflows for computing statistics of T1w-signal differences in both tissue and csf.  