### PR TITLE
Grayskull compat license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jørgen Riseth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,47 @@
+{% set pyproject = load_file_data(RECIPE_DIR ~ '/../pyproject.toml') %}
+{% set project = pyproject['project'] %}
+{% set dependencies = project.get('dependencies', []) %}
+{% set pixidependencies = pyproject.get('tool', {}).get('pixi', {}).get('dependencies', {}) %}
+
+package:
+  name: {{ project['name'] | lower }}
+  version: "{{ project['version'] }}"
+
+source:
+  path: ../
+
+build:
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python {{ project.get('requires-python', '') }}
+    - setuptools
+    - pip
+  run:
+    - python
+    {% for dep in dependencies %}
+    - {{ dep | replace('>=', ' >=') | replace('<=', ' <=') | replace('==', ' ==') | replace('!=', ' !=') | replace('~=', ' ~=') | replace('>', ' >') | replace('<', ' <') }}
+    {% endfor %}
+    {% for name, version_spec in pixidependencies.items() %}
+    - {{ name }} {{ version_spec }}
+    {% endfor %}
+  test:
+    imports:
+      - analysis
+      - brainmeshing
+      - dti
+      - gmri2fem
+      - i2m
+    commands:
+      - pip check
+      - gmri2fem --help
+    requires:
+      - pip
+
+about:
+  summary: "{{ project.get('description', 'No summary provided.') }}"
+  home: "{{ project.get('urls', {}).get('Homepage', 'NO_HOMEPAGE_SET') }}"
+  license: "{{ project['license'] }}"
+  license_file: ../LICENSE # Path to your license file in the project root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "gmri2fem"
 authors = [{ name = "Jørgen Riseth", email = "jnriseth@gmail.com" }]
-version = "0.2.0"
+version = "0.2.1a1"
 requires-python = ">=3.9,<3.13"
 description = "Processing pipeline for glymphatic MRI."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = { "text" = "MIT" }
+license-files = ["LICENSE"]
 dependencies = [
   "loguru",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "gmri2fem"
 authors = [{ name = "Jørgen Riseth", email = "jnriseth@gmail.com" }]
-version = "0.2.0"
+version = "0.2.1a1"
 requires-python = ">=3.9,<3.13"
 description = "Processing pipeline for glymphatic MRI."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = [
   "loguru",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "gmri2fem"
 authors = [{ name = "Jørgen Riseth", email = "jnriseth@gmail.com" }]
-version = "0.2.0"
+version = "0.2.1a1"
 requires-python = ">=3.9,<3.13"
 description = "Processing pipeline for glymphatic MRI."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = [
   "loguru",
   "matplotlib",
@@ -27,6 +28,9 @@ dependencies = [
 
 [project.scripts]
 gmri2fem = "_cli:gmri2fem"
+
+[project.urls]
+Homepage = "https://github.com/jorgenriseth/gMRI2FEM.git"
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
- Added missing license file
- Added conda-recipe which does not rely on grayskull
- updated license entries in pyproject to adhere to PEP639